### PR TITLE
docker-compose.ymlのポート設定を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       POSTGRES_PASSWORD: minivr
       POSTGRES_DB: minivr
     ports:
-      - "5433:5433"
+      - "5432:5432"


### PR DESCRIPTION
## 概要
postgres containerがport 5432で動いているが、
docker composeの設定だとport 5433に対してマッピングを行なっていたため、
localからcontainerに対してアクセスができなかった。
よって、portのマッピング先を5432に修正した。

## 動作確認
```
docker-compose up -d
[+] Running 2/2
 ✔ Network reiya-minivir_default       Created                                                                                                                                                                                                  0.0s
 ✔ Container reiya-minivir-postgres-1  Started
```
```
psql -h localhost -p 5432 -U minivr -d minivr

Password for user minivr:
psql (14.10 (Homebrew), server 16.2 (Debian 16.2-1.pgdg120+2))
WARNING: psql major version 14, server major version 16.
         Some psql features might not work.
Type "help" for help.

minivr=# \l
                              List of databases
   Name    | Owner  | Encoding |  Collate   |   Ctype    | Access privileges
-----------+--------+----------+------------+------------+-------------------
 minivr    | minivr | UTF8     | en_US.utf8 | en_US.utf8 |
 postgres  | minivr | UTF8     | en_US.utf8 | en_US.utf8 |
 template0 | minivr | UTF8     | en_US.utf8 | en_US.utf8 | =c/minivr        +
           |        |          |            |            | minivr=CTc/minivr
 template1 | minivr | UTF8     | en_US.utf8 | en_US.utf8 | =c/minivr        +
           |        |          |            |            | minivr=CTc/minivr
(4 rows)

minivr=# exit
```